### PR TITLE
Change colors to earlyhook

### DIFF
--- a/hooks/colors
+++ b/hooks/colors
@@ -1,6 +1,6 @@
 #!/usr/bin/ash
 
-run_hook() {
+run_earlyhook() {
     if [ -e /consolecolors ]
     then
         setcolors -c /dev/console /consolecolors


### PR DESCRIPTION
`setcolors` clears the output of the console, so it is best to run it as early as possible. That way, as few messages as possible are overwritten.

I made this change so that I could use `setcolors` with [mkinitcpio-archlogo](https://github.com/eworm-de/mkinitcpio-archlogo). Before the change, `setcolors` would overwrite the logo.
