### PR TITLE
initialize COLORS with an empty string

### DIFF
--- a/install/colors
+++ b/install/colors
@@ -4,6 +4,8 @@ build() {
     (
         [[ -s /etc/vconsole.conf ]] && . /etc/vconsole.conf
         
+        COLORS=""
+        
         for COLOR_ID in $(seq 0 15)
         do
             COLOR=$(eval "echo \$COLOR_${COLOR_ID}")


### PR DESCRIPTION
it seems to fix an error during early boot "color 0: invalid color".
see https://github.com/EvanPurkhiser/mkinitcpio-colors/issues/3