### PR TITLE
Make mkinitcpio-colors-git work with systemd based initramfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ First add the `colors` hook to your `/etc/mkinitcpio.conf` files HOOKS list. You
 will probably want to place the hook fairly eairly if you don't want the colors
 to abruptly change.
 
+If you're using `systemd` based `initramfs`, you have to use the `sd-colors` hook and place it after the `systemd` hook, as well as enable the corresponding `setcolors.service` `systemd` service
+
+```
+# systemctl enable setcolors.service
+```
+
 To define colors you will want to edit your `/etc/vconsole.conf` file and
 specify the colors in the format `COLOR_X=hexcode`. Where X is a number between
 0 and 15. For example:

--- a/README.md
+++ b/README.md
@@ -7,15 +7,39 @@ Requires the [setcolors](https://github.com/EvanPurkhiser/linux-vt-setcolors) ut
 
 ### Usage
 
-First add the `colors` hook to your `/etc/mkinitcpio.conf` files HOOKS list. You
+If you have successfully installed this package, either by using the corresponding `AUR` repository, or by
+* copying the contents of the `install` directory to `/usr/lib/initcpio/install`
+* copying the contents of the `hooks` directory to `/usr/lib/initcpio/hooks`
+* copying the `setcolors.service` file to `/usr/lib/systemd/system`
+you can proceed to actually use the `mkinitcpio` hook
+
+First you have to determine, wether you're using a `busybox` or `systemd` based `initramfs`, though.
+
+#### How to tell
+
+The default one is `busybox` for all Arch Linux installations done from an official `archiso`. So at the time of writing, you should know that you're using a `systemd` based `initramfs`, as you would have to actively edit `/etc/mkinitcpio.conf`.
+
+Generally speaking and with no guarantee regarding exceptional cases, if you have the `udev` hook present in your `HOOKS` list in `/etc/mkinitcpio.conf`, you're using a `busybox` based initramfs, if you have the `systemd` hook present, you're using a `systemd` one.
+
+#### `busybox`
+
+Add the `colors` hook to your `/etc/mkinitcpio.conf` `HOOKS` list. You
 will probably want to place the hook fairly eairly if you don't want the colors
 to abruptly change.
 
-If you're using `systemd` based `initramfs`, you have to use the `sd-colors` hook and place it after the `systemd` hook, as well as enable the corresponding `setcolors.service` `systemd` service
+#### `systemd
+
+Add the `colors` hook to your `/etc/mkinitcpio.conf` `HOOKS` list. You
+will probably want to place the hook fairly eairly if you don't want the colors
+to abruptly change, but you will definitely want to place it after the `systemd` hook.
+
+You will then need to enable the `setcolors.service` `systemd` service
 
 ```
 # systemctl enable setcolors.service
 ```
+
+#### In any case
 
 To define colors you will want to edit your `/etc/vconsole.conf` file and
 specify the colors in the format `COLOR_X=hexcode`. Where X is a number between

--- a/install/sd-colors
+++ b/install/sd-colors
@@ -1,0 +1,37 @@
+#!/bin/bash
+build() {
+    # subshell to avoid namespace pollution
+    (
+        [[ -s /etc/vconsole.conf ]] && . /etc/vconsole.conf
+
+        COLORS=""
+
+        for COLOR_ID in $(seq 0 15)
+        do
+            COLOR=$(eval "echo \$COLOR_${COLOR_ID}")
+
+            if [[ ! "$COLOR" ]]
+            then
+                warning "colors: Not all colors specified in configuration"
+                exit 1
+            fi
+
+            COLORS="${COLORS}${COLOR_ID}#${COLOR}\n"
+        done
+
+        echo -ne "$COLORS" > "$BUILDROOT/consolecolors"
+        exit 0
+    )
+
+    add_binary "/usr/bin/setcolors"
+
+    add_systemd_unit "setcolors.service"
+}
+
+help() {
+    cat <<HELPEOF
+This hook will setup the console colors during early user space.
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/setcolors.service
+++ b/setcolors.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup the console colors
+DefaultDependencies=no
+ConditionPathExists=/consolecolors
+
+[Service]
+Type=oneshot
+ExecStart=setcolors -c /dev/console /consolecolors
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
Unfortunately I was lost for days, because the `colors` hook didn't work for me. After over a week of investigation and research I finally solved the problem: This hook is designed for a `busybox` based `initramfs`.
This is why I made the changes. I tried to only add functionality and not remove any.

If you indeed use a `systemd` based `initramfs`, you would need to place `sd-colors` somewhere after `systemd` in your `HOOKS` list of `/etc/mkinitcpio.conf` and enable the `systemd` service with

```
# systemctl enable setcolors.service
```

After that the colors will be set accordingly.

PS: I will also submit changes in a second, for the `AUR` specific stuff, like the `PGKBUILD`.