### PR TITLE
Fix service not being enabled on initramfs (#7)

### DIFF
--- a/install/sd-colors
+++ b/install/sd-colors
@@ -26,6 +26,8 @@ build() {
     add_binary "/usr/bin/setcolors"
 
     add_systemd_unit "setcolors.service"
+
+    add_symlink "/usr/lib/systemd/system/initrd.target.wants/setcolors.service" "setcolors.service"
 }
 
 help() {

--- a/setcolors.service
+++ b/setcolors.service
@@ -6,6 +6,3 @@ ConditionPathExists=/consolecolors
 [Service]
 Type=oneshot
 ExecStart=setcolors -c /dev/console /consolecolors
-
-[Install]
-WantedBy=sysinit.target


### PR DESCRIPTION
- setcolors.service: remove [Install] section because it is not meant to
  be enabled on system.

- sd-colors: add symlink on initrd.target.wants for setcolors.service.

Signed-off-by: GaKu999 <g4ku999@gmail.com>